### PR TITLE
mark-devkit: Bump virtual/latex-base-1.0

### DIFF
--- a/virtual/latex-base/latex-base-1.0.ebuild
+++ b/virtual/latex-base/latex-base-1.0.ebuild
@@ -1,0 +1,14 @@
+# Copyright 1999-2018 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=5
+
+DESCRIPTION="Virtual for basic LaTeX binaries"
+SLOT="0"
+KEYWORDS="alpha amd64 arm arm64 hppa ia64 ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+
+RDEPEND="
+	dev-texlive/texlive-latexrecommended
+	dev-texlive/texlive-fontutils
+	dev-texlive/texlive-fontsrecommended
+	"


### PR DESCRIPTION
Automatic bump of package virtual/latex-base-1.0 for branch mark-xl by mark-bot