### PR TITLE
mark-devkit: Bump app-text/libetonyek-0.1.10-r1

### DIFF
--- a/app-text/libetonyek/libetonyek-0.1.10-r1.ebuild
+++ b/app-text/libetonyek/libetonyek-0.1.10-r1.ebuild
@@ -2,7 +2,7 @@
 
 EAPI=7
 
-MDDS_VER="2.1"
+MDDS_VER="2.0"
 
 DESCRIPTION="Library parsing Apple Keynote presentations"
 HOMEPAGE="https://wiki.documentfoundation.org/DLP/Libraries/libetonyek"


### PR DESCRIPTION
Automatic bump of package app-text/libetonyek-0.1.10-r1 for branch mark-unstable by mark-bot