### PR TITLE
mark-devkit: [mark-unstable] Bump virtual/tex-base-0

### DIFF
--- a/virtual/tex-base/tex-base-0.ebuild
+++ b/virtual/tex-base/tex-base-0.ebuild
@@ -1,0 +1,12 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=5
+
+DESCRIPTION="Virtual for basic TeX binaries (tex, kpathsea)"
+SLOT="0"
+KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+
+RDEPEND="
+		app-text/texlive-core
+	"


### PR DESCRIPTION
Automatic bump of package virtual/tex-base-0 for branch mark-unstable by mark-bot